### PR TITLE
Remove huobi.com from whitelist

### DIFF
--- a/src/white_domains.yml
+++ b/src/white_domains.yml
@@ -4606,7 +4606,6 @@ com:
   hunqingren: 1
   hunt007: 1
   hunuo: 1
-  huobi: 1
   huoche: 1
   huochepiao: 1
   huochepu: 1


### PR DESCRIPTION
`huobi.com` is being blocked by GFW. No longer accessible with direct network.