### PR TITLE
Add *.airdroid.com to white domains

### DIFF
--- a/src/white_domains.yml
+++ b/src/white_domains.yml
@@ -7559,7 +7559,7 @@ com:
   weathercn: 1
   web3389: 1
   web4008: 1
-  web.airdroid: 1
+  airdroid: 1
   webjx: 1
   webpowerchina: 1
   webterren: 1

--- a/src/white_domains.yml
+++ b/src/white_domains.yml
@@ -7559,6 +7559,7 @@ com:
   weathercn: 1
   web3389: 1
   web4008: 1
+  web.airdroid: 1
   webjx: 1
   webpowerchina: 1
   webterren: 1


### PR DESCRIPTION
`*.airdroid.com` this website allows users to upload/download files or send messages while the web is running under the same network, like airdrop.
If this website goes to the proxy gate, the file won't be sent to the android device. 

only allow `web.airdroid.com` doesn't seem to work. So, I add all airdrioid's website to make sure it does work.