### PR TITLE
Add bet365.com to whitelist

### DIFF
--- a/src/white_domains.yml
+++ b/src/white_domains.yml
@@ -2393,6 +2393,7 @@ com:
   best73: 1
   bestb2b: 1
   besttrav: 1
+  bet365: 1
   betrad: 1
   beva: 1
   bf35: 1

--- a/src/white_domains.yml
+++ b/src/white_domains.yml
@@ -2394,6 +2394,7 @@ com:
   bestb2b: 1
   besttrav: 1
   bet365: 1
+  365-868: 1
   betrad: 1
   beva: 1
   bf35: 1


### PR DESCRIPTION
bet365.com can be accessible via direct connections.