### PR TITLE
Remove PayPal from white_domains

### DIFF
--- a/src/white_domains.yml
+++ b/src/white_domains.yml
@@ -6159,7 +6159,6 @@ com:
   paopaoku: 1
   paoxue: 1
   paratong: 1
-  paypal: 1
   pazx888: 1
   pc186: 1
   pc3w: 1


### PR DESCRIPTION
Paypal.com should be never in white lists otherwise the payment maybe won't be finished correctly. 