### PR TITLE
Add missing cdn.jsdelivr.net

### DIFF
--- a/src/white_domains.yml
+++ b/src/white_domains.yml
@@ -8922,6 +8922,7 @@ net:
   zhanzhang: 1
   88rpg: 1
   jsdelivr: 1
+  cdn.jsdelivr: 1
   sina: 1
   wt-cn01: 1
   mingsoft: 1


### PR DESCRIPTION
`cdn.jsdelivr.net` is missed from the white list.