### PR TITLE
Add bytecdntp.com

### DIFF
--- a/src/white_domains.yml
+++ b/src/white_domains.yml
@@ -256,6 +256,7 @@ com:
   cloudvdn: 1
   ctfhub: 1
   bdcloudapi: 1
+  bytecdntp: 1
   novipnoad: 1
   ksyna: 1
   eccdnx: 1


### PR DESCRIPTION
`bytecdntp.com` is a CDN domain.